### PR TITLE
Add graph visualization feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ for file_name in txt_files:
         rag.insert(file.read())
 ```
 
+## Graph Visualization
+Once your files were processed, you may visualize how the graph looks like.
+1. Ensure the file `graph_chunk_entity_relation.graphml` has been written during the main indexation. 
+2. Run `visualize_graph.py`. 
+
+It will create an HTML of your graph. Feel free to open it on your favorite browser.
+* The edge labels are the relationship strength.
+* All nodes have tooltips with their category, description and chunk source.
+
+
 ## Cite
 Please cite our paper if you use this code in your own work:
 ```python

--- a/visualize_graph.py
+++ b/visualize_graph.py
@@ -1,0 +1,25 @@
+import networkx as nx
+from pyvis.network import Network
+
+# Load the GraphML file
+graphml_file = "graph_chunk_entity_relation.graphml"
+try:
+    G = nx.read_graphml(graphml_file)
+except FileNotFoundError as e:
+    friendly_error_msg = f"The file {graphml_file} was not found on this path. Make sure it was generated during indexation."
+    raise Exception(friendly_error_msg)
+
+# Create a Pyvis network
+net = Network(notebook=True, width="100vw", height="100vh", directed=False)
+
+# Convert the NetworkX graph to Pyvis with node data as tooltip
+for node, data in G.nodes(data=True):
+    net.add_node(node, label=node, title=str(data))
+
+# Display the weight as edge label
+for source, target, data in G.edges(data=True):
+    weight = data.get("weight", "")
+    net.add_edge(source, target, label=str(weight))
+
+# Show the network
+net.show('knowledge_graph.html')


### PR DESCRIPTION
# Changes introduced:

Adds `visualize_graph.py`, that generates an HTML visualization of the knowledge graph (`graph_chunk_entity_relation.graphml`):

![Screenshot 2025-03-20 at 23 03 57](https://github.com/user-attachments/assets/505d66ea-8e0c-42ff-93dc-94ac6b478665)

**These changes are important, as they help the user to identify problems with unconnected nodes and easily debug the processed knowledge graph.**
* It adds the weights on the edge label of connected nodes.
* All nodes have a tooltip with category, description and chunk source.

<img width="990" alt="Screenshot 2025-03-20 at 23 17 29" src="https://github.com/user-attachments/assets/51ed1365-12c8-47ce-ad41-c1c800d259a4" />

-----
#### How to test:
1. Process a `sample.txt` or add a ready `graph_chunk_entity_relation.graphml` file.
2. Run `visualize_graph.py`.
3. Open `knowledge_graph.html`.

-----
_Obs:_ If preferred, the functionality could be implemented to automatically generate the visualization HTML, it if executes after graph creation: https://github.com/BUPT-GAMMA/PathRAG/blob/2785a12de7519b1869483b31ed8716179e7bc03e/PathRAG/storage.py#L259-L260
